### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/server/src/main/scripts/throttle_datanode.py
+++ b/server/src/main/scripts/throttle_datanode.py
@@ -22,7 +22,7 @@ import subprocess
 
 # Find the process ID for a java process.
 def find_process_id(java_class, full_java_class):
-  ps_command = "ps aux | grep %s" % java_class 
+  ps_command = "ps aux | grep {0!s}".format(java_class) 
   proc = subprocess.Popen([ps_command], stdout=subprocess.PIPE, shell=True)
   (out, err) = proc.communicate()
   lines = out.split('\n')
@@ -34,7 +34,7 @@ def find_process_id(java_class, full_java_class):
 
 # Find the start and end core for a process.
 def get_cores(pid_str):
-  taskset_command = "taskset -cp %s" % pid_str
+  taskset_command = "taskset -cp {0!s}".format(pid_str)
   proc = subprocess.Popen([taskset_command], stdout=subprocess.PIPE, shell=True)
   (out, err) = proc.communicate()
   cores = out.split()[-1]
@@ -46,8 +46,8 @@ def get_cores(pid_str):
 
 # Set the start and end core for a process.
 def set_cores(pid_str, start_core, end_core):
-  taskset_command = "taskset -acp %d-%d %s" % (start_core, end_core, pid_str)
-  print "Running %s" % taskset_command
+  taskset_command = "taskset -acp {0:d}-{1:d} {2!s}".format(start_core, end_core, pid_str)
+  print "Running {0!s}".format(taskset_command)
   proc = subprocess.Popen([taskset_command], stdout=subprocess.PIPE, shell=True)
   (out, err) = proc.communicate()
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:terrapin?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:terrapin?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
